### PR TITLE
別解を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="jp">
+<html lang="ja">
 
 <head>
   <meta charset="UTF-8">
@@ -8,8 +8,8 @@
   <script src="https://unpkg.com/dayjs"></script>
   <script src="https://unpkg.com/dayjs@1.7.7/locale/ja.js"></script>
   <title>Document</title>
-  <link rel="stylesheet" href="../css/reset.css" />
-  <link rel="stylesheet" href="../css/style.css" />
+  <link rel="stylesheet" href="css/reset.css" />
+  <link rel="stylesheet" href="css/style.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Gorditas&display=swap" rel="stylesheet">
@@ -18,7 +18,7 @@
 <body>
   
       
-    <script src="../js/main.js"></script>
+    <script src="js/main.js"></script>
 </body>
 
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -7,6 +7,19 @@ const array2 = [2, 4, 7, 5, 4, 3, 8];
 const result2 = Array.from(new Set(array2))
 console.log(result2);
 
+// オブジェクト型を使って重複を排除した例を記載します。
+// オブジェクト型を使うと配列の順序は保証されませんが、キーはユニークなので重複を排除することができます。
+const array3 = [2, 4, 5, 7, 5, 4, 3, 8, 2];
+const unique = (arr) => {
+  const obj = {};
+  arr.forEach(elem => obj[elem.toString()] = true);
+  const result = [];
+  Object.keys(obj).forEach(e => {
+    result.push(Number.parseInt(e));
+  });
+  return result;
+}
+console.log(unique(array3));
 
 function isLeapYear(year) {
   if ((year % 4 === 0 && year % 100 !== 0) || year % 400 === 0) {
@@ -28,3 +41,25 @@ if (isLeapYear(checkYear)) {
 } else {
   console.log(checkYear + "年はうるう年ではありません");
 }
+
+
+// isLeapYear を短く書いた例
+function isLeapYear2(year) {
+  // if 文の中で評価している式はそれ自体、審議値を返すことができるので直接 return することができます。
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+const leapYearMessage2 = (year) => isLeapYear2(year)? `${year}年はうるう年です` : `${year}年はうるう年ではありません`;
+
+console.log(leapYearMessage2(2020));
+console.log(leapYearMessage2(2021));
+
+// isLeapYear をアロー関数で書いた例
+// アロー関数は ES6 で追加された構文で基本的に function 関数と同様に関数を定義するための構文ですが、いくつか相違点があります。
+// https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Functions/Arrow_functions
+const isLeapYear3 = (year) => (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+
+const leapYearMessage3 = (year) => isLeapYear3(year)? `${year}年はうるう年です` : `${year}年はうるう年ではありません`;
+
+console.log(leapYearMessage3(2020));
+console.log(leapYearMessage3(2021));


### PR DESCRIPTION
別解の例をいくつか記載いたします。またいくつか気づいた点がございますのでフィードバックいたします。
- `index.html` が `js` ディレクトリに入ってしまっており、JSやCSSの読み込みに `../` という風に `index.html` よりも上位の階層がしていされていたので `index.html` をルートディレクトリに移動しました。
- html タグの lang 属性の値が jp となっていたので ja に修正しました。